### PR TITLE
updates to footer

### DIFF
--- a/fle_site/apps/main/templates/main/partials/_footer.html
+++ b/fle_site/apps/main/templates/main/partials/_footer.html
@@ -88,7 +88,6 @@
                         <li><a href="{% url 'download' %}">Download</a></li>
                         <li><a href="http://kolibridemo.learningequality.org/learn/#/topics">Demo</a></li>
                         <li><a href="{% url 'docs' %}">Documentation</a></li>
-                        <li><a href="{% url 'translate' %}">Help Translate</a></li>
                         <li><a href="{% url 'hardware_grant' %}">Hardware Grant</a></li>
                     </ul>
                 </div>
@@ -97,7 +96,7 @@
                     <br>
                     <ul>
                         <li><a href="{% url 'mission' %}">Learning Equality</a></li>
-                        <li><a href="{% url 'values' %}">Core Values</a></li>
+                        <li><a href="{% url 'values' %}">Core values</a></li>
                         <li><a href="{% url 'team' %}">Team</a></li>
                         <li><a href="{% url 'board' %}">Board of Directors</a></li>
                         <li><a href="{% url 'supporters' %}">Supporters and friends</a></li>
@@ -110,10 +109,10 @@
                     <h5 class="footer-column-headers">KA Lite</h5>
                     <br>
                     <ul>
-                        <li><a href="{% url 'ka_lite' %}">About KA Lite</a></li>
+                        <li><a href="{% url 'ka_lite' %}">About</a></li>
                         <li><a href="http://ka-lite.readthedocs.io/en/latest/installguide/install_main.html">Download</a></li>
-                        <li><a href="http://demo.learningequality.org/">Demo KA Lite</a></li>
-                        <li><a href ="{% url 'infographic' %}">Deploy KA Lite</a></li>
+                        <li><a href="http://demo.learningequality.org/">Demo</a></li>
+                        <li><a href="https://ka-lite.readthedocs.io/en/latest/">Documentation</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">
@@ -121,7 +120,7 @@
                     <br>
                     <ul>
                         <li><a href="{% url 'blog' %}">Read our blog</a></li>
-                        <li><a href="https://community.learningequality.org/">Community forums</a></li>
+                        <li><a href="https://community.learningequality.org/">Join the forums</a></li>
                         <li><a href="{% url 'translate' %}">Help translate</a></li>
                         <li><a href="http://learningequality.us6.list-manage.com/subscribe/post?u=023b9af05922dfc7f47a4fffb&id=d56041116d">Subscribe to newsletter</a></li>
                         <li><a href="{% url 'donate' %}">Donate</a></li>

--- a/fle_site/apps/main/templates/main/partials/_footer.html
+++ b/fle_site/apps/main/templates/main/partials/_footer.html
@@ -86,6 +86,7 @@
                     <ul>
                         <li><a href="{% url 'kolibri' %}">About</a></li>
                         <li><a href="{% url 'download' %}">Download</a></li>
+                        <li><a href="http://kolibridemo.learningequality.org/learn/#/topics">Demo</a></li>
                         <li><a href="{% url 'docs' %}">Documentation</a></li>
                         <li><a href="{% url 'translate' %}">Help Translate</a></li>
                         <li><a href="{% url 'hardware_grant' %}">Hardware Grant</a></li>

--- a/fle_site/apps/main/templates/main/partials/_footer.html
+++ b/fle_site/apps/main/templates/main/partials/_footer.html
@@ -88,7 +88,7 @@
                         <li><a href="{% url 'download' %}">Download</a></li>
                         <li><a href="http://kolibridemo.learningequality.org/learn/#/topics">Demo</a></li>
                         <li><a href="{% url 'docs' %}">Documentation</a></li>
-                        <li><a href="{% url 'hardware_grant' %}">Hardware Grant</a></li>
+                        <li><a href="{% url 'hardware_grant' %}">Hardware grant</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">

--- a/fle_site/apps/main/templates/main/partials/_footer.html
+++ b/fle_site/apps/main/templates/main/partials/_footer.html
@@ -124,7 +124,7 @@
                         <li><a href="{% url 'translate' %}">Help translate</a></li>
                         <li><a href="http://learningequality.us6.list-manage.com/subscribe/post?u=023b9af05922dfc7f47a4fffb&id=d56041116d">Subscribe to newsletter</a></li>
                         <li><a href="{% url 'donate' %}">Donate</a></li>
-                        <li><a href="{% url 'map_add' %}">Share your story!</a></li>
+                        <li><a href="{% url 'map_add' %}">Share your story</a></li>
                         <li><a href="mailto:info@learningequality.org">Contact us</a></li>
                     </ul>
                 </div>

--- a/fle_site/apps/main/templates/main/partials/_footer.html
+++ b/fle_site/apps/main/templates/main/partials/_footer.html
@@ -92,6 +92,16 @@
                     </ul>
                 </div>
                 <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">
+                    <h5 class="footer-column-headers">KA Lite</h5>
+                    <br>
+                    <ul>
+                        <li><a href="{% url 'ka_lite' %}">About</a></li>
+                        <li><a href="http://ka-lite.readthedocs.io/en/latest/installguide/install_main.html">Download</a></li>
+                        <li><a href="http://demo.learningequality.org/">Demo</a></li>
+                        <li><a href="https://ka-lite.readthedocs.io/en/latest/">Documentation</a></li>
+                    </ul>
+                </div>
+                <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">
                     <h5 class="footer-column-headers">About</h5>
                     <br>
                     <ul>
@@ -103,16 +113,6 @@
                         <li><a href="{% url 'press' %}">Press</a></li>
                         <li><a href="{% url 'jobs' %}">Jobs</a></li>
                         <li><a href="{% url 'internships' %}">Internships</a></li>
-                    </ul>
-                </div>
-                <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">
-                    <h5 class="footer-column-headers">KA Lite</h5>
-                    <br>
-                    <ul>
-                        <li><a href="{% url 'ka_lite' %}">About</a></li>
-                        <li><a href="http://ka-lite.readthedocs.io/en/latest/installguide/install_main.html">Download</a></li>
-                        <li><a href="http://demo.learningequality.org/">Demo</a></li>
-                        <li><a href="https://ka-lite.readthedocs.io/en/latest/">Documentation</a></li>
                     </ul>
                 </div>
                 <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12">

--- a/fle_site/apps/main/templates/main/partials/_kolibri-navigation.html
+++ b/fle_site/apps/main/templates/main/partials/_kolibri-navigation.html
@@ -9,17 +9,17 @@
   </a>
 </li>
 <li>
+  <a href="http://kolibridemo.learningequality.org/learn/#/topics">
+    Demo
+  </a>
+</li>
+<li>
   <a href="{% url 'docs' %}">
     Documentation
   </a>
 </li>
 <li>
-  <a href="{% url 'translate' %}">
-    Help Translate
-  </a>
-</li>
-<li>
   <a href="{% url 'hardware_grant' %}">
-    Hardware Grant
+    Hardware grant
   </a>
 </li>


### PR DESCRIPTION
re #358

current state:

![image](https://user-images.githubusercontent.com/2367265/33907968-c3224396-df3b-11e7-9275-25dad6826ebd.png)

Note that our header looks like this, with just a single KA Lite link:

![image](https://user-images.githubusercontent.com/2367265/33908012-e33b2846-df3b-11e7-842f-907d4ad81935.png)

thoughts @laurenlichtman @jeepurs ?
