### PR TITLE
Modify map button hyperlink to map page of current domain

### DIFF
--- a/fle_site/apps/main/templates/main/homepage.html
+++ b/fle_site/apps/main/templates/main/homepage.html
@@ -186,8 +186,8 @@
 				<h2 class="banner-cta">Our Impact</h2>
 				<h4 class="impact-text">We have reached millions of learners with KA Lite all around the globe, and we'll reach millions more with Kolibri! Read about those who shared their story with us and share your own!</h4>
 				<div class="impact-cta">
-				<a href="https://learningequality.org/ka-lite/map/"><button type="button" class="btn btn-success">SEE THE MAP</button></a>
-				<a href="https://learningequality.org/ka-lite/map/add/"><button type="button" class="nav btn btn-success">SHARE YOUR STORY</button></a>
+				<a href="/ka-lite/map/"><button type="button" class="btn btn-success">SEE THE MAP</button></a>
+				<a href="/ka-lite/map/add/"><button type="button" class="nav btn btn-success">SHARE YOUR STORY</button></a>
 				</div>
 			</section>
 


### PR DESCRIPTION
##### Description

This PR is to fix the hyperlink of the map button to current domain's map page.

Previously, the button always points to `learningequality.org`'s map page. This changes map
button's hyperlink to current domain's map page.

For example, `localhost` -> `localhost/ka-lite/map/`

- Modify map button's url to current domain's map page